### PR TITLE
Bugfix: subsection motions can move by start without skipping a subsection

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "haberdashPI",
   "repository": "https://github.com/haberdashPI/vscode-selection-utilities",
   "description": "Kakaune-inspired collection of useful commands for manipulating selections.",
-  "version": "0.6.7",
+  "version": "0.6.6",
   "icon": "logo.png",
   "engines": {
     "vscode": "^1.92.0"

--- a/src/web/unitMotions.ts
+++ b/src/web/unitMotions.ts
@@ -439,7 +439,7 @@ function* resolveUnitBoundaries(
 ): Generator<Range> {
     let backwards: Generator<Range>;
     function* resolveHelper(firstUnit: Range, back: Range): Generator<Range> {
-        if (resolve === Boundary.Start && (!firstUnit?.start || !forward)) {
+        if (resolve === Boundary.Start) {
             if (forward) {
                 if (!firstUnit?.start) {
                     firstUnit = fuseRanges(firstUnit, back);
@@ -465,7 +465,7 @@ function* resolveUnitBoundaries(
                 }
                 yield firstUnit;
             }
-        } else if (resolve === Boundary.End && (!firstUnit?.end || forward)) {
+        } else if (resolve === Boundary.End) {
             if (!forward) {
                 if (!firstUnit?.end) {
                     firstUnit = fuseRanges(firstUnit, back);

--- a/test/specs/moveBySection.ux.mts
+++ b/test/specs/moveBySection.ux.mts
@@ -136,10 +136,10 @@ describe('Section Motion', () => {
             {selectWhole: true, boundary: 'end'},
             `
 
-            joebob
-            bizzle
+            billybob
+            bim
 
-            # B
+            # A.2
             # --------------------`
         );
     });
@@ -161,6 +161,17 @@ describe('Section Motion', () => {
 
     it('Can move backwards by end', async () => {
         await editor.moveCursor(9, 1);
+
+        await parMoveSelects(
+            {selectWhole: true, boundary: 'end', value: -1},
+            `
+
+            billybob
+            bim
+
+            # A.2
+            # --------------------`
+        );
 
         await parMoveSelects(
             {selectWhole: true, boundary: 'end', value: -1},

--- a/test/specs/moveBySection.ux.mts
+++ b/test/specs/moveBySection.ux.mts
@@ -97,6 +97,18 @@ describe('Section Motion', () => {
 
             `
         );
+
+        await editor.moveCursor(10, 1);
+        await parMoveSelects(
+            {selectWhole: true, boundary: 'start'},
+            `# B
+            # --------------------
+
+            billybob
+            bim
+
+            `
+        );
     });
 
     it('Can move by end', async () => {
@@ -107,6 +119,19 @@ describe('Section Motion', () => {
             `# A
             # --------------------`
         );
+        await parMoveSelects(
+            {selectWhole: true, boundary: 'end'},
+            `
+
+            joebob
+            bizzle
+
+            # B
+            # --------------------`
+        );
+
+        await editor.moveCursor(9, 1);
+
         await parMoveSelects(
             {selectWhole: true, boundary: 'end'},
             `

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -54,7 +54,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/*.ux.mts'],
+    specs: ['./test/specs/**/moveBySection.ux.mts'],
     // Patterns to exclude.
     exclude: [
         // 'path/to/excluded/files'

--- a/wdio.conf.mts
+++ b/wdio.conf.mts
@@ -54,7 +54,7 @@ export const config: Options.Testrunner = {
     // The path of the spec files will be resolved relative from the directory of
     // of the config file unless it's absolute.
     //
-    specs: ['./test/specs/**/moveBySection.ux.mts'],
+    specs: ['./test/specs/**/*.ux.mts'],
     // Patterns to exclude.
     exclude: [
         // 'path/to/excluded/files'


### PR DESCRIPTION
Some subection motion would previously skip selecting the current section when `selectWhole = true`, `value = 1` and `unit = 'start'`. This fixes the issue by always checking if
we need the unit boundary that occurs just before the cursor when resolving the unit boundaries.
